### PR TITLE
fix: auto timezone: handle if timezone server is not reachable

### DIFF
--- a/wordclock/src/config.cpp
+++ b/wordclock/src/config.cpp
@@ -99,10 +99,11 @@ void Config::load() {
     Config::automatic_timezone = doc["tz_auto"].as<bool>();
   }
 
+  // load the last known timezone in any case.
+  Config::timezone = doc["timezone"].as<int>();
+
   if (Config::automatic_timezone) {
-    Config::timezone = UtcOffset::getLocalizedUtcOffset();
-  } else {
-    Config::timezone = doc["timezone"].as<int>();
+    UtcOffset::updateLocalizedUtcOffset();
   }
 
   Config::dnd_active = doc["dnd_active"].as<bool>();

--- a/wordclock/src/controller.cpp
+++ b/wordclock/src/controller.cpp
@@ -44,10 +44,11 @@ void Controller::saveTime() {
 
   Config::automatic_timezone = doc["tz_auto"].as<int>() == 1;
 
+  // store the last known value anyway.
+  Config::timezone = doc["tz"].as<int>();
+
   if (Config::automatic_timezone) {
-    Config::timezone = UtcOffset::getLocalizedUtcOffset();
-  } else {
-    Config::timezone = doc["tz"].as<int>();
+    UtcOffset::updateLocalizedUtcOffset();
   }
 
   Config::ntp = doc["ntp"].as<String>();

--- a/wordclock/src/time.cpp
+++ b/wordclock/src/time.cpp
@@ -27,7 +27,7 @@ void Time::loop() {
     Grid::setTime(Time::hour, Time::minute);
 
     if (Config::automatic_timezone) {
-      Config::timezone = UtcOffset::getLocalizedUtcOffset();
+      UtcOffset::updateLocalizedUtcOffset();
       Time::ntpClient.setTimeOffset(Config::timezone);
     }
   }

--- a/wordclock/src/utcOffset.cpp
+++ b/wordclock/src/utcOffset.cpp
@@ -4,7 +4,7 @@
 #include "utcOffset.h"
 #include "config.h"
 
-int UtcOffset::getLocalizedUtcOffset() {
+void UtcOffset::updateLocalizedUtcOffset() {
   HTTPClient http;
   http.begin("http://worldtimeapi.org/api/ip");
   int responseCode = http.GET();
@@ -19,9 +19,25 @@ int UtcOffset::getLocalizedUtcOffset() {
     int dstOffset = doc["dst_offset"].as<int>();
 
     http.end();
-    return utcOffset + dstOffset;
+
+    const int oldTimezone = Config::timezone;
+    const int newTimezone = utcOffset + dstOffset;
+
+    if (oldTimezone != newTimezone) {
+      // save new timezone to config
+      Serial.print("Old timezone: ");
+      Serial.println(Config::timezone);
+      Serial.print("New timezone: ");
+      Serial.println(utcOffset + dstOffset);
+
+      Config::timezone = utcOffset + dstOffset;
+      Config::save();
+    }
+
+    return;
   }
   http.end();
 
-  return Config::timezone; // return last known offset
+  // use last known offset
+  return;
 }

--- a/wordclock/src/utcOffset.cpp
+++ b/wordclock/src/utcOffset.cpp
@@ -9,7 +9,7 @@ void UtcOffset::updateLocalizedUtcOffset() {
   http.begin("http://worldtimeapi.org/api/ip");
   int responseCode = http.GET();
 
-  if (responseCode > 0) {
+  if (responseCode == 200) {
     String payload = http.getString();
 
     StaticJsonDocument<1024> doc;
@@ -24,6 +24,7 @@ void UtcOffset::updateLocalizedUtcOffset() {
     const int newTimezone = utcOffset + dstOffset;
 
     if (oldTimezone != newTimezone) {
+
       // save new timezone to config
       Serial.print("Old timezone: ");
       Serial.println(Config::timezone);

--- a/wordclock/src/utcOffset.h
+++ b/wordclock/src/utcOffset.h
@@ -3,7 +3,7 @@
 
 class UtcOffset {
   public:
-    static int getLocalizedUtcOffset();
+    static void updateLocalizedUtcOffset();
 };
 
 #endif


### PR DESCRIPTION
In case the timezone server is not reachable we use know the
last known timezone instead of falling back to timezone +/-0.

When the we receive a answer from timezone server, it will be
checked if the timezone has changed. Only iff the timezone has
changed the new value will be stored in the config.