### PR TITLE
Update de_DE_alt.cpp

### DIFF
--- a/wordclock/src/language/de_DE_alt.cpp
+++ b/wordclock/src/language/de_DE_alt.cpp
@@ -67,7 +67,7 @@ void Grid_de_DE_alt::setTime(int hour, int minute) {
 	  Led::ids[s].setRGB(Config::color_fg.r, Config::color_fg.g, Config::color_fg.b);
 	}
   }
-
+FastLED.setBrightness(Config::brightness * 255);
   FastLED.show();
 }
 


### PR DESCRIPTION
line 
`FastLED.setBrightness(Config::brightness` * `255);` is missing so brightness control is not working